### PR TITLE
Add global sensors permission patch

### DIFF
--- a/00002-global-sensors-permission-toggle.patch
+++ b/00002-global-sensors-permission-toggle.patch
@@ -1,0 +1,108 @@
+From 4258d64a3a6d8f72a9566ae982aa851a1adeff0c Mon Sep 17 00:00:00 2001
+From: Steve Soltys <steve@stevesoltys.com>
+Date: Thu, 11 Oct 2018 00:05:56 -0400
+Subject: [PATCH] Add sensors permission
+
+---
+ frameworks/base/core/java/android/content/pm/PackageParser.java            |  2 ++
+ frameworks/base/core/res/AndroidManifest.xml                               | 14 ++++++++++++++
+ frameworks/base/core/res/res/values/strings.xml                            | 12 ++++++++++++
+ frameworks/base/services/core/java/com/android/server/pm/permission/PermissionManagerService.java     |  2 +-
+ 4 files changed, 29 insertions(+), 1 deletion(-)
+
+diff --git a/frameworks/base/core/java/android/content/pm/PackageParser.java b/frameworks/base/core/java/android/content/pm/PackageParser.java
+index 2da2cb4c928..531bbca8fc6 100644
+--- a/frameworks/base/core/java/android/content/pm/PackageParser.java
++++ b/frameworks/base/core/java/android/content/pm/PackageParser.java
+@@ -278,6 +278,8 @@ public class PackageParser {
+      */
+     public static final PackageParser.NewPermissionInfo NEW_PERMISSIONS[] =
+         new PackageParser.NewPermissionInfo[] {
++            new PackageParser.NewPermissionInfo(android.Manifest.permission.OTHER_SENSORS,
++                    android.os.Build.VERSION_CODES.CUR_DEVELOPMENT + 1, 0),
+             new PackageParser.NewPermissionInfo(android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                     android.os.Build.VERSION_CODES.DONUT, 0),
+             new PackageParser.NewPermissionInfo(android.Manifest.permission.READ_PHONE_STATE,
+diff --git a/frameworks/base/core/res/AndroidManifest.xml b/frameworks/base/core/res/AndroidManifest.xml
+index c31b3b4989c..5b6026db0c2 100644
+--- a/frameworks/base/core/res/AndroidManifest.xml
++++ b/frameworks/base/core/res/AndroidManifest.xml
+@@ -1129,6 +1129,20 @@
+         android:description="@string/permdesc_useFingerprint"
+         android:protectionLevel="normal" />
+
++    <!-- @hide -->
++    <permission-group android:name="android.permission-group.OTHER_SENSORS"
++        android:icon="@drawable/perm_group_location"
++        android:label="@string/permgrouplab_otherSensors"
++        android:description="@string/permgroupdesc_otherSensors"
++        android:priority="1000" />
++
++    <!-- @hide -->
++    <permission android:name="android.permission.OTHER_SENSORS"
++        android:permissionGroup="android.permission-group.OTHER_SENSORS"
++        android:label="@string/permlab_otherSensors"
++        android:description="@string/permdesc_otherSensors"
++        android:protectionLevel="dangerous" />
++
+     <!-- Allows an app to use device supported biometric modalities.
+          <p>Protection level: normal
+     -->
+diff --git a/frameworks/base/core/res/res/values/strings.xml b/frameworks/base/core/res/res/values/strings.xml
+index 15d1187afa0..00c644f470d 100644
+--- a/frameworks/base/core/res/res/values/strings.xml
++++ b/frameworks/base/core/res/res/values/strings.xml
+@@ -747,6 +747,11 @@
+     <string name="permgrouprequest_sensors">Allow
+         &lt;b><xliff:g id="app_name" example="Gmail">%1$s</xliff:g>&lt;/b> to access sensor data about your vital signs?</string>
+
++    <!-- Title of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permgrouplab_otherSensors">Sensors</string>
++    <!-- Description of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permgroupdesc_otherSensors">access sensor data about orientation, movement, etc.</string>
++
+     <!-- Title for the capability of an accessibility service to retrieve window content. -->
+     <string name="capability_title_canRetrieveWindowContent">Retrieve window content</string>
+     <!-- Description for the capability of an accessibility service to retrieve window content. -->
+@@ -1056,6 +1061,13 @@
+     <string name="permdesc_bodySensors" product="default">Allows the app to access data from sensors
+     that monitor your physical condition, such as your heart rate.</string>
+
++    <!-- Title of the sensors permission, listed so the user can decide whether to allow the application to access sensor data. [CHAR LIMIT=80] -->
++    <string name="permlab_otherSensors">access sensors (like the compass)
++    </string>
++    <!-- Description of the sensors permission, listed so the user can decide whether to allow the application to access data from sensors. [CHAR LIMIT=NONE] -->
++    <string name="permdesc_otherSensors" product="default">Allows the app to access data from sensors
++    monitoring orientation, movement, vibration (including low frequency sound) and environmental data</string>
++
+     <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permlab_readCalendar">Read calendar events and details</string>
+     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+diff --git a/frameworks/base/services/core/java/com/android/server/pm/permission/PermissionManagerService.java b/frameworks/base/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
+index 8cc0de8e322..9615e1f408f 100644
+--- a/frameworks/base/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
++++ b/frameworks/base/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
+@@ -1333,7 +1333,7 @@ public class PermissionManagerService {
+     }
+
+     public static boolean isAlwaysRuntimePermission(final String permission) {
+-        return Manifest.permission.INTERNET.equals(permission);
++        return Manifest.permission.INTERNET.equals(permission) || Manifest.permission.OTHER_SENSORS.equals(permission);
+     }
+
+     private void grantRequestedRuntimePermissionsForUser(PackageParser.Package pkg, int userId,
+diff --git a/frameworks/native/libs/sensor/Sensor.cpp b/frameworks/native/libs/sensor/Sensor.cpp
+index a0e368c7e..4f3fe88b8 100644
+--- a/frameworks/native/libs/sensor/Sensor.cpp
++++ b/frameworks/native/libs/sensor/Sensor.cpp
+@@ -52,6 +52,7 @@ Sensor::Sensor(struct sensor_t const& hwSensor, const uuid_t& uuid, int halVersi
+     mMinDelay = hwSensor.minDelay;
+     mFlags = 0;
+     mUuid = uuid;
++    mRequiredPermission = "android.permission.OTHER_SENSORS";
+
+     // Set fifo event count zero for older devices which do not support batching. Fused
+     // sensors also have their fifo counts set to zero.
+--
+2.16.4
+

--- a/manifest
+++ b/manifest
@@ -1,1 +1,2 @@
 00001-global-internet-permission-toggle.patch
+00002-global-sensors-permission-toggle.patch


### PR DESCRIPTION
Confirmed working, but like the internet permission, can only be set at a global level.

To resolve this for both permissions, we would need to apply the following changes in the future:

https://github.com/AndroidHardeningArchive/platform_packages_apps_PackageInstaller/commit/d4cc88341d19ad4af37216fdf8ad7b8c77f985b6
https://github.com/AndroidHardeningArchive/platform_packages_apps_PackageInstaller/commit/9590f1f79220e2a813726129a07ed4dfa519f58d
https://github.com/AndroidHardeningArchive/platform_packages_apps_PackageInstaller/commit/3b2bd41a541a1f6fa85fa96b93df33b49f6df610
https://github.com/AndroidHardeningArchive/platform_packages_apps_PackageInstaller/commit/d15024c558fbd81046cb845e9ab0f1167fd4a146
https://github.com/AndroidHardeningArchive/platform_packages_apps_PackageInstaller/commit/0ccde5f50b8cfa9a66b655b3b14d77c58944a081
https://github.com/AndroidHardeningArchive/fdroidclient/commit/45548d04f50f7c009717a4f79c3b259af1c33a40

From my understanding, this should create permission groups for `android.permission.INTERNET` and `android.permission.OTHER_SENSORS` so that they can be toggled as a runtime permission.