### PR TITLE
increased default maximum password length to 64

### DIFF
--- a/00004-increase-default-maximum-password-length.patch
+++ b/00004-increase-default-maximum-password-length.patch
@@ -1,0 +1,24 @@
+From 1d7ddaf7708a50f230faa385ce5ec0a3e08adefe Mon Sep 17 00:00:00 2001
+From: Travis Laporte <travis@openshroud.com>
+Date: Sun, 11 Nov 2018 12:38:05 -0500
+Subject: [PATCH] Updated default maximum password length in DevicePolicyManager
+
+---
+ frameworks/base/core/java/android/app/admin/DevicePolicyManager.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/frameworks/base/core/java/android/app/admin/DevicePolicyManager.java b/frameworks/base/core/java/android/app/admin/DevicePolicyManager.java
+index 22367b21221..04b81b9404a 100644
+--- a/frameworks/base/core/java/android/app/admin/DevicePolicyManager.java
++++ b/frameworks/base/core/java/android/app/admin/DevicePolicyManager.java
+@@ -2765,7 +2765,7 @@ public class DevicePolicyManager {
+      */
+     public int getPasswordMaximumLength(int quality) {
+         // Kind-of arbitrary.
+-        return 16;
++        return 64;
+     }
+
+     /**
+--
+2.19.1.windows.1

--- a/manifest
+++ b/manifest
@@ -1,3 +1,4 @@
 00001-global-internet-permission-toggle.patch
 00002-global-sensors-permission-toggle.patch
 00003-disable-menu-entries-in-recovery.patch
+00004-increase-default-maximum-password-length.patch


### PR DESCRIPTION
Allows the use of a longer passphrase instead of a password, which is still convenient when using a fingerprint sensor for most unlocks.

Tested on an update I installed today.