### PR TITLE
Fix patch for Android 10: 00003-disable-menu-entries-in-recovery

### DIFF
--- a/00003-disable-menu-entries-in-recovery.patch
+++ b/00003-disable-menu-entries-in-recovery.patch
@@ -9,45 +9,22 @@ Subject: [PATCH] Disable menu entries in recovery
 * Run graphics test
 
 ---
- bootable/recovery/device.cpp | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ bootable/recovery/recovery_ui/device.cpp | 4 ----
+ 1 file changed, 4 deletions(-)
 
-diff --git a/device.cpp b/device.cpp
-index f881daf..b90520c 100644
---- a/bootable/recovery/device.cpp
-+++ b/bootable/recovery/device.cpp
-@@ -21,13 +21,13 @@ static const char* MENU_ITEMS[] = {
-   "Reboot to bootloader",
-   "Apply update from ADB",
-   "Apply update from SD card",
--  "Wipe data/factory reset",
- #ifndef AB_OTA_UPDATER
-+  "Wipe data/factory reset",
-   "Wipe cache partition",
--#endif  // !AB_OTA_UPDATER
-   "Mount /system",
-   "View recovery logs",
-   "Run graphics test",
-+#endif  // !AB_OTA_UPDATER
-   "Run locale test",
-   "Power off",
-   nullptr,
-@@ -38,13 +38,13 @@ static const Device::BuiltinAction MENU_ACTIONS[] = {
-   Device::REBOOT_BOOTLOADER,
-   Device::APPLY_ADB_SIDELOAD,
-   Device::APPLY_SDCARD,
--  Device::WIPE_DATA,
- #ifndef AB_OTA_UPDATER
-+  Device::WIPE_DATA,
-   Device::WIPE_CACHE,
--#endif  // !AB_OTA_UPDATER
-   Device::MOUNT_SYSTEM,
-   Device::VIEW_RECOVERY_LOGS,
-   Device::RUN_GRAPHICS_TEST,
-+#endif  // !AB_OTA_UPDATER
-   Device::RUN_LOCALE_TEST,
-   Device::SHUTDOWN,
- };
--- 
-2.19.1
-
+diff --git a/recovery_ui/device.cpp b/recovery_ui/device.cpp
+index e7ae1a3..09b3944 100644
+--- a/bootable/recovery/recovery_ui/device.cpp
++++ b/bootable/recovery/recovery_ui/device.cpp
+@@ -31,11 +31,7 @@ static std::vector<std::pair<std::string, Device::BuiltinAction>> g_menu_actions
+   { "Enter fastboot", Device::ENTER_FASTBOOT },
+   { "Apply update from ADB", Device::APPLY_ADB_SIDELOAD },
+   { "Apply update from SD card", Device::APPLY_SDCARD },
+-  { "Wipe data/factory reset", Device::WIPE_DATA },
+   { "Wipe cache partition", Device::WIPE_CACHE },
+-  { "Mount /system", Device::MOUNT_SYSTEM },
+-  { "View recovery logs", Device::VIEW_RECOVERY_LOGS },
+-  { "Run graphics test", Device::RUN_GRAPHICS_TEST },
+   { "Run locale test", Device::RUN_LOCALE_TEST },
+   { "Enter rescue", Device::ENTER_RESCUE },
+   { "Power off", Device::SHUTDOWN },


### PR DESCRIPTION
Fixes patch 00003-disable-menu-entries-in-recovery for Android 10. Successfully tested on Pixel 2.