### PR TITLE
Add sunfish to VoLTE/Wifi patch, Cloudflare DNS and 2-button navigation

### DIFF
--- a/00003-enable-volte-wifi-calling.patch
+++ b/00003-enable-volte-wifi-calling.patch
@@ -1,8 +1,6 @@
-diff --git a/frameworks/base/core/res/res/values/config.xml b/frameworks/base/core/res/res/values/config.xml
-index 04d1eef..5362e2b 100644
---- a/frameworks/base/core/res/res/values/config.xml
-+++ b/frameworks/base/core/res/res/values/config.xml
-@@ -2983,18 +2983,18 @@
+--- a/frameworks/base/core/res/res/values/config.xml	2020-10-13 15:25:39.884460877 +1100
++++ b/frameworks/base/core/res/res/values/config.xml	2020-10-13 15:37:19.844769099 +1100
+@@ -2856,18 +2856,18 @@
      <bool name="imsServiceAllowTurnOff">true</bool>
  
      <!-- Flag specifying whether VoLTE is available on device -->
@@ -24,7 +22,7 @@ index 04d1eef..5362e2b 100644
  
      <!-- Flag specifying whether the device will use the "allow_hold_in_ims_call" carrier config
           option.  When false, the device will support holding of IMS calls, regardless of the
-@@ -3004,15 +3004,15 @@
+@@ -2877,15 +2877,15 @@
      <!-- Flag specifying whether VT should be available for carrier: independent of
           carrier provisioning. If false: hard disabled. If true: then depends on carrier
           provisioning, availability etc -->
@@ -43,14 +41,13 @@ index 04d1eef..5362e2b 100644
  
      <!-- Whether to use voip audio mode for ims call -->
      <bool name="config_use_voip_mode_for_ims">false</bool>
-diff --git a/device/google/bonito/product.prop b/device/google/bonito/product.prop
-index f1247c0..4114493 100644
---- a/device/google/bonito/product.prop
-+++ b/device/google/bonito/product.prop
-@@ -41,6 +41,16 @@ vidc.enc.disable.pq=1
- persist.data.netmgrd.qos.enable=true
- persist.vendor.data.mode=concurrent
- 
+--- a/device/google/bonito/product.prop	2020-10-13 16:46:34.041020350 +1100
++++ b/device/google/bonito/product.prop	2020-10-13 16:47:23.629630753 +1100
+@@ -87,3 +87,13 @@
+ persist.bluetooth.bqr.event_mask=14
+ # BQR minimum report interval configuration
+ persist.bluetooth.bqr.min_interval_ms=500
++
 +#
 +## Enable wifi calling and volte
 +#
@@ -59,8 +56,20 @@ index f1247c0..4114493 100644
 +persist.dbg.vt_avail_ovr=0
 +persist.data.iwlan.enable=true
 +persist.dbg.wfc_avail_ovr=1
-+ro.ril.enable.amr.wideband=1
++o.ril.enable.amr.wideband=1
+--- a/device/google/sunfish/product.prop	2020-10-12 23:25:26.548963534 +1100
++++ b/device/google/sunfish/product.prop	2020-10-12 23:28:37.868652717 +1100
+@@ -94,3 +94,13 @@
+ persist.bluetooth.bqr.event_mask=14
+ # BQR minimum report interval configuration
+ persist.bluetooth.bqr.min_interval_ms=500
 +
- # system props for time-services
- persist.timed.enable=true
- 
++#
++## Enable wifi calling and volte
++#
++persist.dbg.ims_volte_enable=1
++persist.dbg.volte_avail_ovr=1
++persist.dbg.vt_avail_ovr=0
++persist.data.iwlan.enable=true
++persist.dbg.wfc_avail_ovr=1
++o.ril.enable.amr.wideband=1

--- a/00004-use-cloudflare-dns.patch
+++ b/00004-use-cloudflare-dns.patch
@@ -1,0 +1,50 @@
+--- a/frameworks/base/core/res/res/values/config.xml	2020-10-12 17:04:21.290507195 +1100
++++ b/frameworks/base/core/res/res/values/config.xml	2020-10-12 17:05:11.421134762 +1100
+@@ -1825,7 +1825,7 @@
+     <bool name="config_bluetooth_default_profiles">true</bool>
+ 
+     <!-- IP address of the dns server to use if nobody else suggests one -->
+-    <string name="config_default_dns_server" translatable="false">8.8.8.8</string>
++    <string name="config_default_dns_server" translatable="false">1.0.0.1</string>
+ 
+     <!-- The default mobile provisioning apn. Empty by default, maybe overridden by
+          an mcc/mnc specific config.xml -->
+--- a/frameworks/base/services/core/java/com/android/server/connectivity/NetworkDiagnostics.java	2020-10-12 17:12:06.250819855 +1100
++++ b/frameworks/base/services/core/java/com/android/server/connectivity/NetworkDiagnostics.java	2020-10-12 17:12:44.297812971 +1100
+@@ -97,9 +97,9 @@
+ public class NetworkDiagnostics {
+     private static final String TAG = "NetworkDiagnostics";
+ 
+-    private static final InetAddress TEST_DNS4 = NetworkUtils.numericToInetAddress("8.8.8.8");
++    private static final InetAddress TEST_DNS4 = NetworkUtils.numericToInetAddress("1.0.0.1");
+     private static final InetAddress TEST_DNS6 = NetworkUtils.numericToInetAddress(
+-            "2001:4860:4860::8888");
++            "2606:4700:4700::1001");
+ 
+     // For brevity elsewhere.
+     private static final long now() {
+--- a/frameworks/base/packages/SettingsLib/res/values/strings.xml	2020-10-12 17:28:21.302796549 +1100
++++ b/frameworks/base/packages/SettingsLib/res/values/strings.xml	2020-10-12 17:29:16.059298662 +1100
+@@ -1151,9 +1151,9 @@
+     <!-- Hint text for the IP address -->
+     <string name="wifi_ip_address_hint" translatable="false">192.168.1.128</string>
+     <!-- Hint text for DNS -->
+-    <string name="wifi_dns1_hint" translatable="false">8.8.8.8</string>
++    <string name="wifi_dns1_hint" translatable="false">1.0.0.1</string>
+     <!-- Hint text for DNS -->
+-    <string name="wifi_dns2_hint" translatable="false">8.8.4.4</string>
++    <string name="wifi_dns2_hint" translatable="false">1.1.1.1</string>
+     <!-- Hint text for the gateway -->
+     <string name="wifi_gateway_hint" translatable="false">192.168.1.1</string>
+     <!-- Hint text for network prefix length -->
+--- a/frameworks/base/packages/Tethering/src/com/android/networkstack/tethering/TetheringConfiguration.java	2020-10-12 17:31:07.913238850 +1100
++++ b/frameworks/base/packages/Tethering/src/com/android/networkstack/tethering/TetheringConfiguration.java	2020-10-12 17:31:37.199437714 +1100
+@@ -70,7 +70,7 @@
+         "192.168.48.2", "192.168.48.254", "192.168.49.2", "192.168.49.254",
+     };
+ 
+-    private static final String[] DEFAULT_IPV4_DNS = {"8.8.4.4", "8.8.8.8"};
++    private static final String[] DEFAULT_IPV4_DNS = {"1.0.0.1", "1.1.1.1"};
+ 
+     /**
+      * Override enabling BPF offload configuration for tethering.

--- a/00005-2-button-navigation.patch
+++ b/00005-2-button-navigation.patch
@@ -1,0 +1,10 @@
+--- a/frameworks/base/packages/overlays/Android.mk	2020-10-12 16:45:54.430991688 +1100
++++ b/frameworks/base/packages/overlays/Android.mk	2020-10-12 16:49:02.698761203 +1100
+@@ -52,6 +52,7 @@
+ 	IconShapeTeardropOverlay \
+ 	IconShapeVesselOverlay \
+ 	NavigationBarMode3ButtonOverlay \
++	NavigationBarMode2ButtonOverlay \
+ 	NavigationBarModeGesturalOverlay \
+ 	NavigationBarModeGesturalOverlayNarrowBack \
+ 	NavigationBarModeGesturalOverlayWideBack \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently, only the following patches have been updated and confirmed to be work
 * `00001-global-internet-permission-toggle.patch` - this patch adds an additional global network permission.
 * `00002-round-icon.patch` - show round icons in launcher, quick setting tiles.
 * `00003-enable-volte-wifi-calling.patch` - enable VoLTE/4G and WiFi calling (only sargo/bonito and sunfish).
+* `00004-use-cloudflare-dns.patch` - fallback to Cloudflare DNS instead of Google DNS.
 
 ## Submitting Community Patches
 Rules for submitting a patch:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently, only the following patches have been updated and confirmed to be work
 
 * `00001-global-internet-permission-toggle.patch` - this patch adds an additional global network permission.
 * `00002-round-icon.patch` - show round icons in launcher, quick setting tiles.
-* `00003-Enable-WiFi-and-4G-calling-sargo-bonito.patch` - Enable VoLTE/Wifi calling in sargo/bonito (3a/XL).
+* `00003-enable-volte-wifi-calling.patch` - enable VoLTE/4G and WiFi calling (only sargo/bonito and sunfish).
 
 ## Submitting Community Patches
 Rules for submitting a patch:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently, only the following patches have been updated and confirmed to be work
 * `00002-round-icon.patch` - show round icons in launcher, quick setting tiles.
 * `00003-enable-volte-wifi-calling.patch` - enable VoLTE/4G and WiFi calling (only sargo/bonito and sunfish).
 * `00004-use-cloudflare-dns.patch` - fallback to Cloudflare DNS instead of Google DNS.
+* `00005-2-button-navigation.patch` - add back 2-button navigation.
 
 ## Submitting Community Patches
 Rules for submitting a patch:


### PR DESCRIPTION
I've built and have been using these three patches on Sunfish for the last day without any issues.

VoLTE/4G and WiFi calling shows up in settings for both now under `Network & internet > Mobile network`. Testing was as so far as noticing when in a 4G call a `HD` emote now shows in the Phone app and a WiFi signal emote in calls when on WiFi. I assume this same patch could be used for the rest of the devices too.

I haven't actually tested the patch that changes the DNS fallback (I am still using the patch though), but I assume they work as intended since they are the same changes made in GrapheneOS.

I'm not sure why the 2-button navigation was taken out of AOSP in Android 11, but it's still present in the factory image so it should be there (also I've gotten too used the swiping it offers that I can't live without it).